### PR TITLE
feat: prepare a root site

### DIFF
--- a/presign/settings/base.py
+++ b/presign/settings/base.py
@@ -49,7 +49,9 @@ class Base(Configuration):
     TEMPLATES = [
         {
             "BACKEND": "django.template.backends.django.DjangoTemplates",
-            "DIRS": [],
+            "DIRS": [
+                BASE_DIR / "presign/templates",
+            ],
             "APP_DIRS": True,
             "OPTIONS": {
                 "context_processors": [

--- a/presign/templates/root.html
+++ b/presign/templates/root.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+    <div>
+        This is a presign installation. The control interface is <a href="{% url "control:index" %}">here</a>.
+    </div>
+ 
+{% endblock content %}

--- a/presign/urls.py
+++ b/presign/urls.py
@@ -7,6 +7,8 @@ from django.views.static import serve
 
 from presign.base.views import serve_signed
 
+from . import views
+
 
 def get_status_patterns(prefix, view=serve, **kwargs):
     return [
@@ -23,6 +25,7 @@ def static_pattern(prefix, view=serve, **kwargs):
 
 
 urlpatterns = [
+    path("", views.HomeView.as_view()),
     path(settings.ADMIN_URL_BASE, admin.site.urls),
     path("i18n/", include("django.conf.urls.i18n")),
     path("accounts/", include("django.contrib.auth.urls")),

--- a/presign/views.py
+++ b/presign/views.py
@@ -1,0 +1,5 @@
+from django.views.generic import TemplateView
+
+
+class HomeView(TemplateView):
+    template_name = "root.html"


### PR DESCRIPTION
This PR prepares a root site, so at least something is shown on the root page.
We might choose to list events as opt-in/opt-out on the root page.